### PR TITLE
구독서비스 백엔드, 프론트엔드 수정

### DIFF
--- a/BackEnd/scheduler-service/src/main/java/com/example/schedulerservice/vo/ResponseSubscription.java
+++ b/BackEnd/scheduler-service/src/main/java/com/example/schedulerservice/vo/ResponseSubscription.java
@@ -3,6 +3,7 @@ package com.example.schedulerservice.vo;
 import com.example.schedulerservice.dto.SubscriptionGradeDto;
 import lombok.Data;
 
+import javax.persistence.Column;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
@@ -17,6 +18,8 @@ public class ResponseSubscription implements Serializable {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private String cancelContent;
+
+    private Integer changeSubGradeId;
 
     private SubscriptionGradeDto subscriptionGradeDto;
 }

--- a/BackEnd/subscription-service/pom.xml
+++ b/BackEnd/subscription-service/pom.xml
@@ -108,6 +108,17 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
+        <!--동적 쿼리 Query DSL-->
+        <!-- https://mvnrepository.com/artifact/com.querydsl/querydsl-jpa -->
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.querydsl/querydsl-apt -->
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -133,6 +144,24 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <!-- 동적 쿼리 Query DSL 플러그인 -->
+            <!-- plugin -->
+            <plugin>
+                <groupId>com.mysema.maven</groupId>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.1.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/generated-sources/java</outputDirectory>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/jpa/SubscriptionRepository.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/jpa/SubscriptionRepository.java
@@ -1,15 +1,18 @@
 package com.example.subscriptionservice.jpa;
 
 import com.example.subscriptionservice.entity.SubscriptionEntity;
-import com.example.subscriptionservice.entity.SubscriptionGradeEntity;
-import org.springframework.data.domain.Sort;
+import com.example.subscriptionservice.querydsl.SubscriptionRespositoryQueryDsl;
+import org.apache.tomcat.jni.Local;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 
-public interface SubscriptionRepository extends JpaRepository<SubscriptionEntity, Long> {
+public interface SubscriptionRepository extends JpaRepository<SubscriptionEntity, Long>, SubscriptionRespositoryQueryDsl {
     SubscriptionEntity findByUserId(String userId);
 
     SubscriptionEntity findBySubId(long subId);
@@ -17,4 +20,10 @@ public interface SubscriptionRepository extends JpaRepository<SubscriptionEntity
     Iterable<SubscriptionEntity> findByStatusAndNextPaymentDateLessThanEqual(Character status, LocalDateTime end);
 
     Long countByUserId(String userId);
+
+    Page<SubscriptionEntity> findByStatus(Character status, Pageable pageRequest);
+
+    Page<SubscriptionEntity> findByStatusAndStartDateBetween(Character status, LocalDateTime startDate, LocalDateTime endDate, Pageable pageRequest);
+
+    Long countByStartDateBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionRespositoryQueryDsl.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionRespositoryQueryDsl.java
@@ -1,0 +1,12 @@
+package com.example.subscriptionservice.querydsl;
+
+import com.example.subscriptionservice.entity.SubscriptionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SubscriptionRespositoryQueryDsl {
+    Page<SubscriptionEntity> findAllBySearchKeyword(SubscriptionSearchParam subscriptionSearchParam, Pageable pageRequest);
+    List<SubscriptionEntity> findAllBySearchKeyword(SubscriptionSearchParam subscriptionSearchParam);
+}

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionRespositoryQueryDslImpl.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionRespositoryQueryDslImpl.java
@@ -1,0 +1,69 @@
+package com.example.subscriptionservice.querydsl;
+
+import com.example.subscriptionservice.entity.SubscriptionEntity;
+import com.example.subscriptionservice.entity.QSubscriptionEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+public class SubscriptionRespositoryQueryDslImpl extends QuerydslRepositorySupport implements SubscriptionRespositoryQueryDsl{
+    public SubscriptionRespositoryQueryDslImpl() {
+        super(SubscriptionEntity.class);
+    }
+
+    @Override
+    public Page<SubscriptionEntity> findAllBySearchKeyword(SubscriptionSearchParam subscriptionSearchParam, Pageable pageRequest) {
+        JPQLQuery<SubscriptionEntity> query = findAllBySearchKeywordQuery(subscriptionSearchParam, pageRequest);
+
+        // 페이징 처리를 위한 fetchResults (조회 리스트 + 전체 개수를 포함한 QueryResults
+        QueryResults<SubscriptionEntity> queryResults = query.fetchResults();
+
+        return new PageImpl<SubscriptionEntity>(queryResults.getResults(), pageRequest, queryResults.getTotal());
+    }
+
+    @Override
+    public List<SubscriptionEntity> findAllBySearchKeyword(SubscriptionSearchParam subscriptionSearchParam) {
+        JPQLQuery<SubscriptionEntity> query = findAllBySearchKeywordQuery(subscriptionSearchParam, null);
+        return query.fetchResults().getResults();
+    }
+
+    private JPQLQuery<SubscriptionEntity> findAllBySearchKeywordQuery(SubscriptionSearchParam param, Pageable pageable) {
+        QSubscriptionEntity subscriptionEntity = QSubscriptionEntity.subscriptionEntity;
+        JPQLQuery<SubscriptionEntity> query = from(subscriptionEntity);
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // startDate to endDate
+        if(param.getStartDate() != null && param.getEndDate() != null) {
+            builder.and(subscriptionEntity.startDate.between(param.getStartDate(),
+                    param.getEndDate()));
+        }
+
+        // search 타입과 값에 따라 달라지는 동적 쿼리
+        if(param.getSearchType().equals("all")) {
+            builder.and(subscriptionEntity.userId.contains(param.getSearchValue()));
+        }
+        else if(param.getSearchType().equals("userId")) {
+            builder.and(subscriptionEntity.userId.contains(param.getSearchValue()));
+        }
+
+        // 페이징
+        if (pageable != null) {
+            query.limit(pageable.getPageSize());
+            query.offset(pageable.getOffset());
+        }
+
+        // order by
+        OrderSpecifier<LocalDateTime> startDate = subscriptionEntity.startDate.desc();
+
+        return query.distinct().where(builder).orderBy(startDate);
+    }
+}

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionSearchParam.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/querydsl/SubscriptionSearchParam.java
@@ -1,0 +1,24 @@
+package com.example.subscriptionservice.querydsl;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+public class SubscriptionSearchParam {
+    private String searchType;
+    private String searchValue;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    public SubscriptionSearchParam(String searchType, String searchValue, LocalDate startDate, LocalDate endDate) {
+        this.searchType = searchType;
+        this.searchValue = searchValue;
+
+        if(startDate != null && endDate != null) {
+            this.startDate = startDate.atStartOfDay();
+            this.endDate = endDate.plusDays(1L).atStartOfDay();
+        }
+    }
+}

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/service/SubscriptionService.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/service/SubscriptionService.java
@@ -6,11 +6,15 @@ import com.example.subscriptionservice.dto.SubscriptionGradeDto;
 import com.example.subscriptionservice.entity.SubscriptionEntity;
 import com.example.subscriptionservice.entity.SubscriptionGradeEntity;
 import com.example.subscriptionservice.entity.SubscriptionShipsEntity;
+import com.example.subscriptionservice.querydsl.SubscriptionSearchParam;
 import com.example.subscriptionservice.vo.RequestCancelSubscription;
 import com.example.subscriptionservice.vo.RequestUpdateSubscription;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 
 public interface SubscriptionService {
     /*구독 등급 조회*/
@@ -30,6 +34,15 @@ public interface SubscriptionService {
 
     /*구독 취소*/
     void cancelSubscription(RequestCancelSubscription requestCancelSubscription);
+
+    /*구독 전체조회*/
+    Page<SubscriptionDto> getAllSubscription(Pageable pageRequest);
+
+    Page<SubscriptionDto> getSubscriptionByStatus(Character status, Pageable pageRequest);
+
+    Page<SubscriptionDto> getSubscriptionByStatusAndStartDateBetween(Character status, LocalDate startDate, LocalDate endDate, Pageable pageRequest);
+
+    Page<SubscriptionDto> getSubscriptionBySearchKeyword(SubscriptionSearchParam subscriptionSearchParam, Pageable pageReqeust);
 
     /*구독 조회*/
     SubscriptionDto getSubscription(String userId);
@@ -69,4 +82,8 @@ public interface SubscriptionService {
 
     /*총 매출액 조회*/
     Long getTotalRevenue();
+
+    Long getTotalSubscriptionCnt();
+
+    Long getNewSubscriptionCnt();
 }

--- a/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/vo/ResponseSubscription.java
+++ b/BackEnd/subscription-service/src/main/java/com/example/subscriptionservice/vo/ResponseSubscription.java
@@ -20,6 +20,7 @@ public class ResponseSubscription implements Serializable {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private String cancelContent;
+    private Integer changeSubGradeId;
 
     private SubscriptionGradeDto subscriptionGradeDto;
 }

--- a/BackEnd/subscription-service/src/main/resources/application.yml
+++ b/BackEnd/subscription-service/src/main/resources/application.yml
@@ -22,6 +22,17 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true  # 페이징 처리 후 page=0이 아닌 1로 처리
+        default-page-size: 10         # 페이징 처리 시 한 페이지 당 10개의 데이터를 가져오는걸 기본으로 한다
+        max-page-size: 2000           # 페이징 처리 시 페이지가 2000개 이상 넘어가지 않도록 한다. (너무 큰 페이징이 나왔을 때를 방지)
+        # 기본으로 설정되어 있으나, 직접 설정으로 바꿔줄 수 있는 것들
+        page-parameter: page          # 페이징 처리 시 페이지라는 인자 명은 page
+        size-parameter: size          # 페이징 처리 시 자르려는 데이터의 사이즈 명은 size
+      sort:
+        sort-parameter: sort          # 페이징 처리로 나온 데이터들을 정렬하는 인자 명은 sort
   datasource:
     driver-class-name:
     url:

--- a/Frontend-admin/src/routes.js
+++ b/Frontend-admin/src/routes.js
@@ -10,6 +10,8 @@ const UserDetail = React.lazy(() => import('./views/user/UserDetail'))
 const AdminUser = React.lazy(() => import('./views/user/AdminUser'))
 const AdminAlert = React.lazy(() => import('./views/user/alert/Alert'))
 
+const Subscrption = React.lazy(() => import('./views/subscription/Subscrption'))
+
 // theme
 const Colors = React.lazy(() => import('./views/theme/colors/Colors'))
 const Typography = React.lazy(() => import('./views/theme/typography/Typography'))
@@ -76,7 +78,7 @@ const routes = [
   { path: '/orders/paylist', name: '결제 전체 내역', component: Home},
 
   { path: '/subscription', name: '구독 관리' },
-  { path: '/subscription/list', name: '구독 전체 내역', component: Home},
+  { path: '/subscription/list', name: '구독 전체 내역', component: Subscrption},
 
   { path: '/ships', name: '배송 관리'},
   { path: '/ships/list', name: '배송 전체 내역', component: AdminShipping },

--- a/Frontend-admin/src/views/subscription/SubscprionTable.js
+++ b/Frontend-admin/src/views/subscription/SubscprionTable.js
@@ -1,0 +1,76 @@
+import { CTable, CTableBody, CTableDataCell, CTableHead, CTableHeaderCell, CTableRow } from '@coreui/react';
+import React from 'react';
+
+export default function SubscprionTable({ subscriptionDatas, setSubscriptionDatas, loading }) {
+
+    const getStatusText = (status) => {
+        switch (status) {
+            case '1':
+                return "구독중 (패키지확정 전)"
+            case '2':
+                return "구독중 (패키지확정 완료)"
+            case '3':
+                return "구독취소"
+            default:
+                break;
+        }
+    }
+
+    // 3자리마다 ,(콤마) 붙이기 (8000000 => 8,000,000)
+    function numberToCommasNumber(number) {
+        return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    }
+
+    return (
+        <div className="cart-main-area pt-20 pb-2">
+            <div className="container">
+                {/* <h3 className="cart-page-title">회원 목록</h3> */}
+                <div className="row">
+                    <div className="col-lg-12 col-md-12">
+                        <div className="table-content">
+                            <div className="card" style={{ paddingBottom: "20px" }}>
+                                <CTable hover>
+                                    <CTableHead>
+                                        <CTableRow>
+                                            <CTableHeaderCell scope="col">#</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">아이디</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">구독상태</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">구독등급</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">금액</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">시작일</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">최근결제일</CTableHeaderCell>
+                                            <CTableHeaderCell scope="col">다음결제일</CTableHeaderCell>
+                                        </CTableRow>
+                                    </CTableHead>
+                                    <CTableBody>
+                                        {
+                                            loading === false ?
+                                                (
+                                                    subscriptionDatas.map((item) => (
+                                                        <CTableRow key={item.id}>
+                                                            <CTableHeaderCell scope="row">{item.subId}</CTableHeaderCell>
+                                                            <CTableDataCell>{item.userId}</CTableDataCell>
+                                                            <CTableDataCell>{getStatusText(item.status)}</CTableDataCell>
+                                                            <CTableDataCell>{item.subscriptionGradeDto.name}</CTableDataCell>
+                                                            <CTableDataCell>{numberToCommasNumber(item.subscriptionGradeDto.monthlyFee)}</CTableDataCell>
+                                                            <CTableDataCell>{item.startDate.split('T')[0]}</CTableDataCell>
+                                                            <CTableDataCell>{item.lastPaymentDate.split('T')[0]}</CTableDataCell>
+                                                            <CTableDataCell>{item.nextPaymentDate.split('T')[0]}</CTableDataCell>
+                                                        </CTableRow>
+                                                    ))
+                                                )
+                                                :
+                                                null
+                                        }
+
+                                    </CTableBody>
+                                </CTable>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/Frontend-admin/src/views/subscription/Subscrption.js
+++ b/Frontend-admin/src/views/subscription/Subscrption.js
@@ -1,0 +1,329 @@
+import React, { Fragment, useEffect, useState } from "react";
+import DatePicker, {registerLocale} from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import axios from 'axios';
+import * as moment from 'moment';
+import { CPagination, CPaginationItem } from '@coreui/react';
+import { ClipLoader } from "react-spinners";
+import SubscprionTable from './SubscprionTable';
+import ko from "date-fns/locale/ko"; // the locale you want
+
+const Subscrption = (props) => {
+    const [loading, setLoading] = useState(true);
+    const [subscriptionDatas, setSubscriptionDatas] = useState([]);
+
+    const [startDate, setStartDate] = useState(new Date("2021/01/01"));
+    const [endDate, setEndDate] = useState(new Date());
+
+    const [searchType, setSearchType] = useState("all");
+    const [searchValue, setSearchValue] = useState("");
+
+    const [codeType, setCodeType] = useState('0');
+
+    const [totalPages, setTotalPages] = useState(0);
+    const [currentPages, setCurrentPages] = useState(1);
+    const [whatPages, setWhatPages] = useState(0); // 0: 전체 조회 1: 타입별 조회 2: 검색 조회
+
+    const totalFindUrl = `/subscription-service/subscription?page=`;
+
+    // datepicker 한국어 설정
+    registerLocale("ko", ko);
+
+    useEffect(() => {
+
+        let token = localStorage.getItem('token');
+        const result = axios.get(totalFindUrl,{
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        })
+        .then((res) => {
+            console.log(res.data);
+            if(res.status === 200) {
+                setSubscriptionDatas(res.data.content);
+                setTotalPages(res.data.totalPages);
+                setCurrentPages(res.data.number + 1);
+                setWhatPages(0);
+                setLoading(false);
+            }
+        })
+    }, []);
+
+    const rendering = () => {
+        const result = [];
+        for (let i = 1; i <= totalPages; i++) {
+            if (i === currentPages) {
+                result.push(
+                    <CPaginationItem
+                        active
+                        onClick={(e) => { pageHandler(i, whatPages, e) }}
+                    >{i}</CPaginationItem>
+                )
+            }
+            else {
+                result.push(
+                    <CPaginationItem
+                        onClick={(e) => { pageHandler(i, whatPages, e) }}
+                    >{i}</CPaginationItem>
+                )
+            }
+
+        }
+        return result;
+    }
+
+    const searchTypeChange = (e) => {
+        e.preventDefault();
+        setSearchType(e.target.value);
+    }
+
+    const searchValueChange = (e) => {
+        e.preventDefault();
+        setSearchValue(e.target.value);
+    }
+
+    const typeHandler = (type, pageNum, e) => {
+        e.preventDefault();
+        setLoading(true);
+        
+        console.log(type);
+
+        let token = localStorage.getItem('token');
+
+        const start = moment(startDate, 'YYYY-MM-DD').format().split('T')[0];
+        const end = moment(endDate, 'YYYY-MM-DD').format().split('T')[0];
+
+        console.log(start)
+        console.log(end)
+
+        axios.get(`/subscription-service/subscription/status/${type}?page=${pageNum}&startDate=${start}&endDate=${end}`, {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        })
+            .then((res) => {
+                console.log(res.data);
+                if(res.status === 200) {
+                    setSubscriptionDatas(res.data.content);
+                    setTotalPages(res.data.totalPages);
+                    setCurrentPages(res.data.number + 1);
+                    setWhatPages(1);
+                    setCodeType(type);
+                    setLoading(false);
+                }
+                else {
+                    alert('오류가 발생했습니다.');
+                }
+
+            })
+            .catch((err) => {
+                console.log(err);
+                alert('오류가 발생했습니다');
+            })
+    }
+
+    const searchHandler = (pageNum, e) => {
+        e.preventDefault();
+        console.log(pageNum);
+        setLoading(true);
+
+        let token = localStorage.getItem('token');
+
+        const start = moment(startDate, 'YYYY-MM-DD').format().split('T')[0];
+        const end = moment(endDate, 'YYYY-MM-DD').format().split('T')[0];
+
+        console.log(start)
+        console.log(end)
+
+        console.log(searchType)
+        console.log(searchValue)
+
+        const result = axios.get(`/subscription-service/subscription/keyword/search?` +
+            `page=${pageNum}&searchType=${searchType}&searchValue=${searchValue}` +
+            `&startDate=${start}&endDate=${end}`,
+            {
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            })
+            .then((res) => {
+                console.log(res.data);
+                if (res.status === 200) {
+                    setSubscriptionDatas(res.data.content);
+                    setTotalPages(res.data.totalPages);
+                    setCurrentPages(res.data.number + 1);
+                    setWhatPages(2);
+                    setLoading(false);
+                }
+                else {
+                    alert('오류가 발생했습니다.');
+                }
+            })
+            .catch((err) => {
+                console.log(err)
+                alert('오류가 발생했습니다');
+            })
+
+    }
+
+    const pageHandler = (pageNum, pageFlag, e) => {
+        e.preventDefault();
+        console.log(pageFlag);
+        setLoading(true);
+        setCurrentPages(pageNum);
+        let token = localStorage.getItem('token');
+        // 전체 구독 내역 조회
+        if(pageFlag === 0) {
+            const result = axios.get(totalFindUrl+pageNum, {
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            })
+                .then((res) => {
+                    console.log(res.data);
+                    if (res.status === 200) {
+                        setSubscriptionDatas(res.data.content);
+                        setTotalPages(res.data.totalPages);
+                        setCurrentPages(res.data.number + 1);
+                        setLoading(false);
+                    }
+                })
+        }
+        // 코드타입 별 알림 내역 조회
+        else if(pageFlag === 1) {
+            typeHandler(codeType, pageNum, e);
+        }
+        // 키워드 검색 별 알림 내역 조회
+        else if(pageFlag === 2) {
+            searchHandler(pageNum, e);
+        }
+    }
+
+    return(
+        <Fragment>
+            <div className="container">
+                {/* 타입 별 리스트 조회 */}
+                <div className="row mb-4">
+                    <div className="col-12 col-lg-4 col-sm-6">
+                        <div className="alert-card card mb-2" onClick={(e) => typeHandler('1', 1, e)}
+                            >
+                            <div className="card-body d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h4>구독중 (패키지확정 전)</h4>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="col-12 col-lg-4 col-sm-6">
+                        <div className="alert-card card mb-2" onClick={(e) => typeHandler('2', 1, e)}>
+                            <div className="card-body d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h4>구독중 (패키지확정 완료)</h4>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="col-12 col-lg-4 col-sm-6">
+                        <div className="alert-card card mb-2" onClick={(e) => typeHandler('3', 1, e)}>
+                            <div className="card-body d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h4>구독취소</h4>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {/* <div className="col-12 col-lg-3 col-sm-6">
+                        <div className="alert-card card mb-2" onClick={(e) => typeHandler('302', 1, e)}>
+                            <div className="card-body d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h4>배송완료</h4>
+                                </div>
+                            </div>
+                        </div>
+                    </div> */}
+                </div>
+
+                <div className="row">
+                    <div className="col-12 col-lg-2" >
+                        <DatePicker
+                            style={{textAlign:"center"}}
+                            selected={startDate}
+                            onChange={(date) => setStartDate(date)}
+                            selectsStart
+                            startDate={startDate}
+                            endDate={endDate}
+                            locale="ko"
+                        />
+                    </div>
+                    <div className="col-12 col-lg-1 mt-1" style={{textAlign:"center"}}>
+                        <span style={{fontSize: "20px"}}>~</span>
+                    </div>
+                    <div className="col-12 col-lg-2">
+                        <DatePicker
+                            selected={endDate}
+                            onChange={(date) => setEndDate(date)}
+                            selectsEnd
+                            startDate={startDate}
+                            endDate={endDate}
+                            minDate={startDate}
+                            locale="ko"
+                        />
+                    </div>
+                    <div className="col-12 col-lg-2">
+                        <select className="form-select" style={{ marginBottom: "20px", border: "1px solid LightGray" }}
+                            name="searchType"
+                            type="radio"
+                            value={searchType}
+                            onChange={searchTypeChange}
+                        >
+                            <option value="all">전체</option>
+                            <option value="userId">아이디</option>
+                        </select>
+                    </div>
+                    <div className="col-12 col-lg-5">
+                        <div className="input-group">
+                            <input
+                                className="form-control"
+                                onChange={searchValueChange}
+                                type="text"
+                                placeholder="입력"
+                                value={searchValue}
+                            />
+                            <button type="button" className="btn btn-primary" onClick={(e) => searchHandler(1, e)}>
+                                <i className="fas fa-search" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {
+                loading ?
+                    (
+                        <div className="kako-login-loading-box" style={{ textAlign: "center", paddingTop: "250px" }}>
+                            <ClipLoader
+                                color="gray"
+                                loading={loading}
+                                size="50px" />
+                        </div>
+                    )
+                    :
+                    (
+                        <div>
+                            <SubscprionTable
+                                subscriptionDatas={subscriptionDatas}
+                                setSubscriptionDatas={setSubscriptionDatas}
+                                loading={loading}
+                            />
+                            <CPagination className="pb-40" aria-label="Page navigation example">
+                                {rendering()}
+                            </CPagination>
+                        </div>
+                    )
+            }
+
+
+        </Fragment>
+    );
+}
+    
+export default Subscrption;


### PR DESCRIPTION
[프론트엔드]
- 관리자 페이지 구독관리 - 구독 전체 내역 조회 View 추가 및 구독 내역 조회 API 연동

[백엔드]
- 관리자 구독 내역 조회 API (검색 및 페이징 처리)
- 구독 수 조회 (전체 구독수, 신규 구독수)
- 특정회원 구독 정보 조회 시 다음 결제시 변경될 구독등급 변수 response vo에 추가